### PR TITLE
GPX-Download

### DIFF
--- a/fetch.php
+++ b/fetch.php
@@ -12,6 +12,9 @@ $supported = array(
 		'tpl' => 'templates/stats.tpl',
 		'contr' => 'fetchStats',
 	),
+	'gpxfile' => array(
+		'tpl' => 'templates/gpxfile.tpl',
+	),
 );
 
 if(isset($_REQUEST['content']) && isset($supported[$_REQUEST['content']]))

--- a/index.php
+++ b/index.php
@@ -51,6 +51,8 @@ require 'config.php';
 									<h3>Statistisches</h3>
 									<ul>Communities im Api-File: <span id="countCom"></ul>
 									<ul>Verarbeitete Knoten: <span id="countNodes"></ul>
+									<h3>Download</h3>
+									<p><a href="fetch.php?content=gpxfile">Alle Knoten als GPX-Datei</a></p>
 								</div>
 								<div role="tabpanel" class="tab-pane" id="about"></div>
 								<div role="tabpanel" class="tab-pane" id="stats"></div>

--- a/index.php
+++ b/index.php
@@ -53,6 +53,7 @@ require 'config.php';
 									<ul>Verarbeitete Knoten: <span id="countNodes"></ul>
 									<h3>Download</h3>
 									<p><a href="fetch.php?content=gpxfile">Alle Knoten als GPX-Datei</a></p>
+									<p><a href="#" id="gpxlink">Aktuell sichtbare Knoten als GPX-Datei</a></p>
 								</div>
 								<div role="tabpanel" class="tab-pane" id="about"></div>
 								<div role="tabpanel" class="tab-pane" id="stats"></div>

--- a/js/meta_map.js
+++ b/js/meta_map.js
@@ -173,6 +173,12 @@ function setDirectLink()
 	}
 
 	$('#direktlink').text(newLink);
+
+
+	// set link to limited GPX file:
+	var bounds = map.getBounds();
+	var newGpxLink = document.location.origin + '/fetch.php?content=gpxfile&minlat='+bounds.getSouth()+'&maxlat='+bounds.getNorth()+'&minlon='+bounds.getWest()+'&maxlon='+bounds.getEast();
+	$('#gpxlink').attr("href", newGpxLink)
 }
 
 /**

--- a/templates/gpxfile.tpl
+++ b/templates/gpxfile.tpl
@@ -1,0 +1,31 @@
+<?php
+
+header("Content-Type: text/xml");
+header('Content-Disposition: attachment; filename="ffnodes.gpx"');
+
+?>
+<gpx version="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+
+<?php
+
+$filename = dirname(__FILE__).'/../cache/result_routers.json';
+if ( !file_exists($filename) )
+{
+	echo "<!-- cache is still empty -->\n\n";
+}
+else
+{
+	$routerArray = json_decode(file_get_contents($filename));
+	foreach ($routerArray as $r)
+	{
+		echo '<wpt lon="'.$r->long.'" lat="'.$r->lat.'">
+<name>'.htmlspecialchars($r->name).'</name>
+<desc>'.htmlspecialchars($r->name).' ('.htmlspecialchars($r->community).')</desc>
+</wpt>
+
+';
+	}
+}
+
+?>
+</gpx>

--- a/templates/gpxfile.tpl
+++ b/templates/gpxfile.tpl
@@ -1,5 +1,16 @@
 <?php
 
+$haveBounds = false;
+if (isset($_REQUEST['minlat']) && isset($_REQUEST['maxlat']) && isset($_REQUEST['minlon']) && isset($_REQUEST['maxlon']))
+{
+    $minLat = $_REQUEST['minlat'];
+    $minLon = $_REQUEST['minlon'];
+    $maxLat = $_REQUEST['maxlat'];
+    $maxLon = $_REQUEST['maxlon'];
+    $haveBounds = true;
+}
+
+
 header("Content-Type: text/xml");
 header('Content-Disposition: attachment; filename="ffnodes.gpx"');
 
@@ -18,6 +29,11 @@ else
 	$routerArray = json_decode(file_get_contents($filename));
 	foreach ($routerArray as $r)
 	{
+		if ($haveBounds && ($r->lat < $minLat || $r->lat > $maxLat || $r->long < $minLon || $r->long > $maxLon))
+		{
+			continue;
+		}
+
 		echo '<wpt lon="'.$r->long.'" lat="'.$r->lat.'">
 <name>'.htmlspecialchars($r->name).'</name>
 <desc>'.htmlspecialchars($r->name).' ('.htmlspecialchars($r->community).')</desc>


### PR DESCRIPTION
Mit diesen Änderungen kann man alle Freifunk-Knoten als GPX-Datei runterladen, z.B. um sie auf dem Smartphone auf einer Karte anzuzeigen. Man kann entweder alle Knoten runterladen (im Moment ca. 1.5MB) oder nur die Knoten, die im sichtbaren Bereich liegen.

Die GPX-Datei enthält einfach die Werte, die aus dem (hoffentlich vorhandenen) Cache gelesen wurden; also auch Offline-Knoten.