### PR TITLE
Enable parsing of more than one map per community

### DIFF
--- a/lib/nodelistparser.php
+++ b/lib/nodelistparser.php
@@ -466,7 +466,7 @@ class nodeListParser
 					{
 						// found something
 						$parsedSources[] = $url;
-						//break;
+						// don't break here to enable more than one active map
 					}
 				}
 				else

--- a/lib/nodelistparser.php
+++ b/lib/nodelistparser.php
@@ -466,7 +466,7 @@ class nodeListParser
 					{
 						// found something
 						$parsedSources[] = $url;
-						break;
+						//break;
 					}
 				}
 				else
@@ -776,7 +776,7 @@ class nodeListParser
 		if(in_array($comUrl, $this->_urlBlackList))
 		{
 			$this->_addCommunityMessage($comUrl.' is blacklisted - skipping');
-			return false;	
+			return false;
 		}
 
 		$result = simpleCachedCurl($comUrl, $this->_curlCacheTime, $this->_debug);


### PR DESCRIPTION
The Freifunk community from Chemnitz is transitioning to gluon at the moment. The old mesh is viewable via an old FFMAP installation. The new nodes are in a Meshviewer installation. These are missing in the public map at the moment.
The small change will include the missing nodes.